### PR TITLE
Fix switched interpretation of coefficients.

### DIFF
--- a/mixed/pulp.qmd
+++ b/mixed/pulp.qmd
@@ -134,8 +134,8 @@ mmod <- lmer(bright ~ 1+(1|operator), pulp)
 faraway::sumary(mmod)
 ```
 
-We see slightly less variation within operators (SD=0.261) than between
-operators (SD=0.326). 
+We see slightly less variation between operators ($\hat\sigma_a=0.261$) than within
+operators ($\sigma_\epsilon=0.326$). 
 
 ## Hypothesis testing
 


### PR DESCRIPTION
Dear Julian, if I'm not mistaken, the interpretation of the coefficients was switched in the comments of the first example. Here is a fix. Thanks for sharing this.